### PR TITLE
fix: loosen type checking for satisfy()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "assertron",
-  "version": "3.1.1",
+  "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/satisfy.spec.ts
+++ b/src/satisfy.spec.ts
@@ -112,3 +112,9 @@ test('can check parent property', t => {
   satisfy(boo, { foo: 'foo' })
   t.pass()
 })
+
+test('actual of type any should not have type checking error', t => {
+  let actual: any = { a: 1 }
+  satisfy(actual, { a: 1 })
+  t.pass()
+})

--- a/src/satisfy.ts
+++ b/src/satisfy.ts
@@ -8,7 +8,9 @@ export type SatisfyExpected<T> = {
  */
 export function satisfy<
   Actual,
-  Expected extends Partial<SatisfyExpected<Actual>>>(actual: Actual, expected: Expected) {
+  // Using `| any` to disable type checking due to:
+  // https://github.com/Microsoft/TypeScript/issues/20247
+  Expected extends Partial<SatisfyExpected<Actual>> | any>(actual: Actual, expected: Expected) {
   satisfyInternal(actual, expected, '')
 }
 export class FailedPredicate extends Error {


### PR DESCRIPTION
Due to:
https://github.com/Microsoft/TypeScript/issues/20247