### PR TITLE
feat: change default export for assertron

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { AssertOrder } from './AssertOrder'
-export default AssertOrder
+import { assertron } from './assertron'
+export default assertron
 
 export * from './AssertOrder'
 export * from './assertron'


### PR DESCRIPTION
BREAKING CHANGE:
default export changed to assertron

Exporting AssertOrder as default export was for backward compatibility purpose.

AssertOrder don't really need to naming flexibility provided by default export.

`assertron` however would benefit from the flexible naming.