### PR TITLE
fix: add wait with callback overload

### DIFF
--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -7,7 +7,7 @@ cp.spawn('tsc', ['-w'], { shell: true })
   .stdout.on('data', (data) => {
     const text = data.toString()
     process.stdout.write(text)
-    if (/.*Compilation complete/.test(text)) {
+    if (/.*Watching for file changes/.test(text)) {
       if (!ava) {
         ava = cp.spawn('ava', ['-w'], {
           stdio: 'inherit',

--- a/src/AssertOrder.spec.ts
+++ b/src/AssertOrder.spec.ts
@@ -424,3 +424,33 @@ test('wait(step) will wait for specific step to happen', async t => {
   await order.wait(1)
   t.is(order.currentStep, 2)
 })
+
+test('wait(step, callback) will execute the callback and return void', async () => {
+  const order = new AssertOrder(2)
+
+  order.wait(1, () => {
+    order.once(2)
+  })
+  order.once(1)
+
+  return order.end(100)
+})
+
+test('wait(step, callback) will execute the async callback but not wait for it and return void', async () => {
+  const order = new AssertOrder(1)
+  const o2 = new AssertOrder(1)
+
+  order.wait(1, () => {
+    return new Promise(a => {
+      setImmediate(() => {
+        o2.once(1)
+        a()
+      })
+    })
+  })
+  order.once(1)
+
+  order.end()
+  return o2.end(100)
+})
+

--- a/src/AssertOrder.ts
+++ b/src/AssertOrder.ts
@@ -135,10 +135,13 @@ export class AssertOrder {
 
     return this.state.moveSubStep()
   }
-  wait(step: number) {
-    return new Promise(a => {
-      this.on(step, a)
-    })
+  wait(step: number): Promise<void>
+  wait(step: number, callback: () => void): void
+  wait(step: number, callback?: () => void) {
+    if (callback)
+      this.on(step, callback)
+    else
+      return new Promise<any>(a => { this.on(step, a) })
   }
   private assert(method: string, step: number) {
     if (this.state.isNotValid(step)) {


### PR DESCRIPTION
This fix tslint when it is used within callback.