### PR TITLE
fix: repeat() to throw FailOnOccurance error

### DIFF
--- a/src/assertron/repeat.spec.ts
+++ b/src/assertron/repeat.spec.ts
@@ -1,4 +1,5 @@
 import a from '..'
+import { FailOnOccurance } from './repeat';
 
 test('repeat function n times', () => {
   let count = 0
@@ -20,4 +21,29 @@ test('repeat async function n times sequentially', async () => {
 
   expect(actual).toBe('12345678910')
   expect(actual).toBe(aa)
+})
+
+test('error is captured as inner error and indicate which call failed', () => {
+  let count = 0
+  const err = a.throws(() => a.repeat(() => {
+    ++count
+    if (count === 5) throw new Error('failed')
+  }, 10), FailOnOccurance)
+
+  expect(err.occurance).toBe(5)
+  expect(err.error.message).toBe('failed')
+})
+
+test('rejected error is captured as inner error and indicate which call failed', async () => {
+  let count = 0
+  let err = await a.throws(a.repeat(() => new Promise((a, r) => {
+    setTimeout(() => {
+      ++count
+      if (count === 5) r(new Error('failed'))
+      else a()
+    }, Math.random() * 10)
+  }), 10), FailOnOccurance)
+
+  expect(err.occurance).toBe(5)
+  expect(err.error.message).toBe('failed')
 })

--- a/src/assertron/repeat.ts
+++ b/src/assertron/repeat.ts
@@ -1,20 +1,37 @@
 import isPromise from 'is-promise';
+import AssertionError from 'assertion-error'
 
 /**
  * Repeat the specified function n times and return the last result.
  * If the result is a promise, it will run the function sequentially.
  */
 export function repeat<R>(fn: () => R | (() => Promise<R>), times: number): ReturnType<typeof fn> extends Promise<R> ? Promise<R> : R {
-  const result = fn()
-  if (isPromise(result)) {
-    if (times <= 1) return result as any
-    return result.then(() => repeat(fn, times - 1)) as any
-  }
-  else {
-    let result
-    for (let i = 1; i < times; i++) {
-      result = fn()
+  return repeatRecur(fn, 1, times)
+}
+
+function repeatRecur<R>(fn: () => R | (() => Promise<R>), i: number, times: number): ReturnType<typeof fn> extends Promise<R> ? Promise<R> : R {
+  try {
+    const result = fn()
+    if (i === times) return result as any
+
+    if (isPromise(result)) {
+      return result.then(
+        () => repeatRecur(fn, i + 1, times),
+        (e) => { throw new FailOnOccurance(i, e) }
+      ) as any
     }
-    return result
+    else {
+      return repeatRecur(fn, i + 1, times)
+    }
+  }
+  catch (e) {
+    if (e instanceof FailOnOccurance) throw e
+    throw new FailOnOccurance(i, e)
+  }
+}
+
+export class FailOnOccurance extends AssertionError {
+  constructor(public occurance: number, public error: any) {
+    super(`Failed on ${occurance} occurance`)
   }
 }


### PR DESCRIPTION
when one of the calls failed.