### PR TITLE
fix!: drop node 8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "watch": "yarn test:watch"
   },
   "dependencies": {
-    "is-node": "^1.0.2",
     "is-promise": "^4.0.0",
     "iso-error": "^4.3.5",
     "path-equal": "^1.2.2",
@@ -107,5 +106,8 @@
       "path": "./tslib/index.js",
       "limit": "15 KB"
     }
-  ]
+  ],
+  "engines": {
+    "node": ">= 10"
+  }
 }

--- a/ts/assert-order/StateMachine.ts
+++ b/ts/assert-order/StateMachine.ts
@@ -1,20 +1,5 @@
-import isNode from 'is-node'
+import { performance } from 'perf_hooks'
 import { State } from './types.js'
-
-// istanbul ignore next
-function nodeVersionIsOrAbove(major: number, minor = 0, patch = 0) {
-  // without this, systemJS will complain `process is not defined`
-  if (!global.process) return false
-  const versionString = process.version.startsWith('v') ? process.version.slice(1) : process.version
-  const [actualMajor, actualMinor, actualPatch] = versionString.split('.').map(s => parseInt(s, 10))
-  const checking = major * 1000 * 1000 + minor * 1000 + patch
-  const actual = actualMajor * 1000 * 1000 + actualMinor * 1000 + actualPatch
-  return actual >= checking
-}
-
-// istanbul ignore next
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const performance = isNode && nodeVersionIsOrAbove(8, 5) ? require('perf_hooks').performance : undefined
 
 let timeTracker: { start(): void, taken(): number }
 // istanbul ignore else

--- a/typings/is-node.d.ts
+++ b/typings/is-node.d.ts
@@ -1,4 +1,0 @@
-declare module 'is-node' {
-  const isNode: boolean
-  export = isNode
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2322,7 +2322,6 @@ __metadata:
     eslint-config-prettier: ^8.5.0
     eslint-plugin-harmony: ^7.1.0
     husky: ^8.0.1
-    is-node: ^1.0.2
     is-promise: ^4.0.0
     iso-error: ^4.3.5
     jest: ^28.1.1
@@ -4807,13 +4806,6 @@ __metadata:
   version: 2.0.2
   resolution: "is-negative-zero@npm:2.0.2"
   checksum: f3232194c47a549da60c3d509c9a09be442507616b69454716692e37ae9f37c4dea264fb208ad0c9f3efd15a796a46b79df07c7e53c6227c32170608b809149a
-  languageName: node
-  linkType: hard
-
-"is-node@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "is-node@npm:1.0.2"
-  checksum: 94234415e5690a485aae4cd7ad9645673bac34c819e219c947f2261d2c2b03991e9c89017f804b5eac10a3c33da681e6fbaaffff65aa545b873a5dab347026ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This enable ESM usage as in ESM `require()` is not supported.