### PR TITLE
fix: perf_hooks reference

### DIFF
--- a/ts/assert-order/StateMachine.ts
+++ b/ts/assert-order/StateMachine.ts
@@ -1,4 +1,4 @@
-import { performance } from 'perf_hooks'
+import * as perf from 'perf_hooks'
 import { State } from './types.js'
 
 let timeTracker: { start(): void, taken(): number }
@@ -13,11 +13,12 @@ if (process && typeof process.hrtime === 'function') {
     }
   }
 }
-else if (performance && typeof performance.now === 'function') {
+else if (perf.performance && typeof perf.performance.now === 'function') {
+  const now = perf.performance.now
   let tick: number
   timeTracker = {
-    start() { tick = performance.now() },
-    taken() { return performance.now() - tick }
+    start() { tick = now() },
+    taken() { return now() - tick }
   }
 }
 else {


### PR DESCRIPTION
In browser environment (e.g. jsdom),
the named export could fail when there is no polyfill. e.g.:

```sh
"performance" is not exported by "__vite-browser-external"
```

Use namespace export should avoid that problem